### PR TITLE
call /bin/sh instead of bash

### DIFF
--- a/src/pb.sh
+++ b/src/pb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 endpoint="${PB_ENDPOINT:-https://ptpb.pw}"
 jq_args="${PB_JSON:--r .url}"


### PR DESCRIPTION
The script is POSIX-clean: Debian's `checkbashism` script doesn't detect any oddity and manual inspection seems to confirm this should run correctly under any POSX-respecting shell. This includes `dash` (Debian), `sh` (BSD's "Bourne shell"), or even fancy ones like `zsh`.

Closes: #7